### PR TITLE
Enhanced Hourly Aggregation with Encounter Block Support and Unit-Aware Column Fixes

### DIFF
--- a/clifpy/clif_orchestrator.py
+++ b/clifpy/clif_orchestrator.py
@@ -822,6 +822,7 @@ class ClifOrchestrator:
         self,
         aggregation_config: Dict[str, List[str]],
         wide_df: Optional[pd.DataFrame] = None,
+        id_name: str = 'hospitalization_id',
         memory_limit: str = '4GB',
         temp_directory: Optional[str] = None,
         batch_size: Optional[int] = None
@@ -845,6 +846,11 @@ class ClifOrchestrator:
             }
         wide_df : pd.DataFrame, optional
             Wide dataset DataFrame. If None, uses the stored wide_df from create_wide_dataset()
+        id_name : str, default='hospitalization_id'
+            Column name to use for grouping aggregation. Options:
+            - 'hospitalization_id': Group by individual hospitalizations (default)
+            - 'encounter_block': Group by encounter blocks (after encounter stitching)
+            - Any other ID column present in the wide dataset
         memory_limit : str, default='4GB'
             DuckDB memory limit (e.g., '4GB', '8GB')
         temp_directory : str, optional
@@ -861,6 +867,11 @@ class ClifOrchestrator:
             # Using stored wide_df (after create_wide_dataset())
             co.create_wide_dataset(...)
             hourly_df = co.convert_wide_to_hourly(aggregation_config=config)
+
+            # Using encounter blocks after stitching
+            co.run_stitch_encounters()
+            co.create_wide_dataset(...)
+            hourly_df = co.convert_wide_to_hourly(aggregation_config=config, id_name='encounter_block')
 
             # Using explicit wide_df parameter
             hourly_df = co.convert_wide_to_hourly(wide_df=my_df, aggregation_config=config)
@@ -880,6 +891,7 @@ class ClifOrchestrator:
         return convert_wide_to_hourly(
             wide_df=wide_df,
             aggregation_config=aggregation_config,
+            id_name=id_name,
             memory_limit=memory_limit,
             temp_directory=temp_directory,
             batch_size=batch_size

--- a/tests/test_wide.ipynb
+++ b/tests/test_wide.ipynb
@@ -297,7 +297,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Building expressions: 100%|██████████| 1/1 [00:00<00:00, 1128.71column/s]\n"
+      "Building expressions: 100%|██████████| 1/1 [00:00<00:00, 1721.09column/s]\n"
      ]
     },
     {
@@ -311,7 +311,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing: 100%|██████████| 1/1 [00:00<00:00, 80.09operation/s]"
+      "Processing: 100%|██████████| 1/1 [00:00<00:00, 98.21operation/s]"
      ]
     },
     {
@@ -343,10 +343,7 @@
       "lab_result_dttm: null count after conversion= 0\n",
       "Using directly provided parameters\n",
       "Loading clif_patient_assessments.parquet\n",
-      "Data loaded successfully from clif_patient_assessments.parquet\n",
-      "recorded_dttm: null count before conversion= 0\n",
-      "recorded_dttm: Converted from UTC to your timezone (US/Eastern).\n",
-      "recorded_dttm: null count after conversion= 0\n"
+      "Data loaded successfully from clif_patient_assessments.parquet\n"
      ]
     },
     {
@@ -360,6 +357,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "recorded_dttm: null count before conversion= 0\n",
+      "recorded_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "recorded_dttm: null count after conversion= 0\n",
       "Using directly provided parameters\n",
       "Loading clif_medication_admin_continuous.parquet\n",
       "Data loaded successfully from clif_medication_admin_continuous.parquet\n",
@@ -626,11 +626,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "7gsgdi0y3yk",
    "metadata": {},
-   "outputs": [],
-   "source": "# Test hourly aggregation with encounter blocks\nimport pandas as pd\n\n# Define aggregation configuration for various column types\naggregation_config = {\n    'mean': ['map', 'spo2', 'weight_kg'],  # Vitals\n    'max': ['creatinine', 'bilirubin_total'],  # Labs - worst values\n    'min': ['platelet_count'],  # Labs - lowest count\n    'first': ['gcs_total'],  # Assessments - first in hour\n    'boolean': ['norepinephrine_mcg_min', 'epinephrine_mcg_min', 'phenylephrine_mcg_min', \n                'vasopressin_u_min', 'dopamine_mcg_min', 'dobutamine_mcg_min', \n                'milrinone_mcg_min']  # Meds - any use in hour\n}\n\n# Make sure we have a wide dataset with encounter_block column\nif 'encounter_block' not in clif.wide_df.columns:\n    print(\"WARNING: encounter_block not in wide_df columns. Ensure encounter stitching was performed.\")\n    print(\"Available columns:\", clif.wide_df.columns.tolist())\nelse:\n    print(f\"Wide dataset ready: {clif.wide_df.shape}\")\n    print(f\"Unique encounter blocks in wide_df: {clif.wide_df['encounter_block'].nunique()}\")\n\n\ntry:\n    hourly_df_enc = clif.convert_wide_to_hourly(\n        aggregation_config=aggregation_config,\n        id_name='encounter_block'\n    )\n    \n    print(f\"✓ Shape: {hourly_df_enc.shape}\")\n    print(f\"✓ Unique encounter_blocks: {hourly_df_enc['encounter_block'].nunique()}\")\n    print(f\"✓ Sample columns: {list(hourly_df_enc.columns)[:10]}...\")\n    print(f\"✓ Hour range: nth_hour {hourly_df_enc['nth_hour'].min()} to {hourly_df_enc['nth_hour'].max()}\")\nexcept Exception as e:\n    print(f\"✗ Error: {e}\")"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wide dataset ready: (36749, 28)\n",
+      "Unique encounter blocks in wide_df: 272\n",
+      "Starting optimized hourly aggregation using DuckDB...\n",
+      "Input dataset shape: (36749, 28)\n",
+      "Memory limit: 4GB\n",
+      "Creating hourly buckets...\n",
+      "Calculating nth_hour...\n",
+      "Columns not in aggregation_config, defaulting to 'first' with '_c' postfix:\n",
+      "  - hospitalization_id\n",
+      "  - age_at_admission\n",
+      "  - po2_arterial\n",
+      "  - hospital_id\n",
+      "  - in_dttm\n",
+      "  - out_dttm\n",
+      "  - location_category\n",
+      "  - location_type\n",
+      "  - hosp_id_day_key\n",
+      "  - angiotensin\n",
+      "\n",
+      "Processing aggregations by type:\n",
+      "- Extracting base columns...\n",
+      "- Processing max aggregation...\n",
+      "  ✓ max complete (2 columns)\n",
+      "- Processing min aggregation...\n",
+      "  ✓ min complete (1 columns)\n",
+      "- Processing mean aggregation...\n",
+      "  ✓ mean complete (3 columns)\n",
+      "- Processing first aggregation...\n",
+      "  ✓ first complete (11 columns)\n",
+      "- Processing boolean aggregation...\n",
+      "  ✓ boolean complete (7 columns)\n",
+      "\n",
+      "Merging aggregation results...\n",
+      "\n",
+      "Hourly aggregation complete: 1087 hourly records\n",
+      "Columns in hourly dataset: 30\n",
+      "✓ Shape: (1087, 30)\n",
+      "✓ Unique encounter_blocks: 272\n",
+      "✓ Sample columns: ['encounter_block', 'event_time_hour', 'nth_hour', 'hour_bucket', 'patient_id', 'day_number', 'creatinine_max', 'bilirubin_total_max', 'platelet_count_min', 'map_mean']...\n",
+      "✓ Hour range: nth_hour 0 to 1078\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test hourly aggregation with encounter blocks\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Define aggregation configuration for various column types\n",
+    "aggregation_config = {\n",
+    "    'mean': ['map', 'spo2', 'weight_kg'],  # Vitals\n",
+    "    'max': ['creatinine', 'bilirubin_total'],  # Labs - worst values\n",
+    "    'min': ['platelet_count'],  # Labs - lowest count\n",
+    "    'first': ['gcs_total'],  # Assessments - first in hour\n",
+    "    'boolean': ['norepinephrine_mcg_min', 'epinephrine_mcg_min', 'phenylephrine_mcg_min', \n",
+    "                'vasopressin_u_min', 'dopamine_mcg_min', 'dobutamine_mcg_min', \n",
+    "                'milrinone_mcg_min']  # Meds - any use in hour\n",
+    "}\n",
+    "\n",
+    "# Make sure we have a wide dataset with encounter_block column\n",
+    "if 'encounter_block' not in clif.wide_df.columns:\n",
+    "    print(\"WARNING: encounter_block not in wide_df columns. Ensure encounter stitching was performed.\")\n",
+    "    print(\"Available columns:\", clif.wide_df.columns.tolist())\n",
+    "else:\n",
+    "    print(f\"Wide dataset ready: {clif.wide_df.shape}\")\n",
+    "    print(f\"Unique encounter blocks in wide_df: {clif.wide_df['encounter_block'].nunique()}\")\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    hourly_df_enc = clif.convert_wide_to_hourly(\n",
+    "        aggregation_config=aggregation_config,\n",
+    "        id_name='encounter_block'\n",
+    "    )\n",
+    "    \n",
+    "    print(f\"✓ Shape: {hourly_df_enc.shape}\")\n",
+    "    print(f\"✓ Unique encounter_blocks: {hourly_df_enc['encounter_block'].nunique()}\")\n",
+    "    print(f\"✓ Sample columns: {list(hourly_df_enc.columns)[:10]}...\")\n",
+    "    print(f\"✓ Hour range: nth_hour {hourly_df_enc['nth_hour'].min()} to {hourly_df_enc['nth_hour'].max()}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"✗ Error: {e}\")"
+   ]
   },
   {
    "cell_type": "code",
@@ -645,11 +728,12 @@
        "       'patient_id', 'day_number', 'creatinine_max', 'bilirubin_total_max',\n",
        "       'platelet_count_min', 'map_mean', 'spo2_mean', 'weight_kg_mean',\n",
        "       'gcs_total_first', 'hospitalization_id_c', 'age_at_admission_c',\n",
-       "       'dobutamine_mcg_min_c', 'dopamine_mcg_min_c', 'epinephrine_mcg_min_c',\n",
-       "       'milrinone_mcg_min_c', 'norepinephrine_mcg_min_c',\n",
-       "       'phenylephrine_mcg_min_c', 'vasopressin_u_min_c', 'po2_arterial_c',\n",
-       "       'hospital_id_c', 'in_dttm_c', 'out_dttm_c', 'location_category_c',\n",
-       "       'location_type_c', 'hosp_id_day_key_c', 'angiotensin_c'],\n",
+       "       'po2_arterial_c', 'hospital_id_c', 'in_dttm_c', 'out_dttm_c',\n",
+       "       'location_category_c', 'location_type_c', 'hosp_id_day_key_c',\n",
+       "       'angiotensin_c', 'norepinephrine_mcg_min_boolean',\n",
+       "       'epinephrine_mcg_min_boolean', 'phenylephrine_mcg_min_boolean',\n",
+       "       'vasopressin_u_min_boolean', 'dopamine_mcg_min_boolean',\n",
+       "       'dobutamine_mcg_min_boolean', 'milrinone_mcg_min_boolean'],\n",
        "      dtype='object')"
       ]
      },
@@ -661,14 +745,6 @@
    "source": [
     "hourly_df_enc.columns"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a5d69397",
-   "metadata": {},
-   "outputs": [],
-   "source": "'mean': ['map', 'spo2', 'weight_kg'],  # Vitals\n'max': ['creatinine', 'bilirubin_total'],  # Labs - worst values\n'min': ['platelet_count'],  # Labs - lowest count\n'first': ['gcs_total'],  # Assessments - first in hour\n'boolean': ['norepinephrine_mcg_min', 'epinephrine_mcg_min', 'phenylephrine_mcg_min', \n            'vasopressin_u_min', 'dopamine_mcg_min', 'dobutamine_mcg_min', \n            'milrinone_mcg_min']  # Meds - any use in hour (unit-aware column names)"
   }
  ],
  "metadata": {

--- a/tests/test_wide.ipynb
+++ b/tests/test_wide.ipynb
@@ -184,10 +184,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "77c9fcf4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data directory: /Users/sudo_sage/Documents/WORK/clifpy/clifpy/data/clif_demo\n",
+      "Output directory: /Users/sudo_sage/Documents/WORK/clifpy/examples/output\n",
+      "Using directly provided parameters\n",
+      "ClifOrchestrator initialized.\n",
+      "Using directly provided parameters\n",
+      "Loading clif_hospitalization.parquet\n",
+      "Data loaded successfully from clif_hospitalization.parquet\n",
+      "admission_dttm: null count before conversion= 0\n",
+      "admission_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "admission_dttm: null count after conversion= 0\n",
+      "discharge_dttm: null count before conversion= 0\n",
+      "discharge_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "discharge_dttm: null count after conversion= 0\n",
+      "Using directly provided parameters\n",
+      "Loading clif_adt.parquet\n",
+      "Data loaded successfully from clif_adt.parquet\n",
+      "in_dttm: null count before conversion= 0\n",
+      "in_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "in_dttm: null count after conversion= 0\n",
+      "out_dttm: null count before conversion= 275\n",
+      "out_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "out_dttm: null count after conversion= 275\n",
+      "Performing encounter stitching with time interval of 6 hours...\n",
+      "Encounter stitching completed successfully.\n",
+      "Total hospitalizations: 275\n",
+      "Total encounter blocks: 272\n",
+      "\n",
+      "Encounter mapping shape: (275, 2)\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "from clifpy import ClifOrchestrator\n",
@@ -239,10 +274,224 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "bc9fd01e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using directly provided parameters\n",
+      "Loading clif_vitals.parquet\n",
+      "Data loaded successfully from clif_vitals.parquet\n",
+      "recorded_dttm: null count before conversion= 0\n",
+      "recorded_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "recorded_dttm: null count after conversion= 0\n",
+      "Using CLIF standard outlier ranges\n",
+      "\n",
+      "Building outlier expressions...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Building expressions: 100%|██████████| 1/1 [00:00<00:00, 1128.71column/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Applying outlier filtering...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing: 100%|██████████| 1/1 [00:00<00:00, 80.09operation/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Vitals Table - Category Statistics:\n",
+      "  dbp                 :  14351 values →      0 nullified (  0.0%)\n",
+      "  heart_rate          :  13913 values →      0 nullified (  0.0%)\n",
+      "  height_cm           :     71 values →      2 nullified (  2.8%)\n",
+      "  map                 :  14368 values →     20 nullified (  0.1%)\n",
+      "  respiratory_rate    :  13913 values →      0 nullified (  0.0%)\n",
+      "  sbp                 :  14356 values →      0 nullified (  0.0%)\n",
+      "  spo2                :  13540 values →      3 nullified (  0.0%)\n",
+      "  temp_c              :   3767 values →      5 nullified (  0.1%)\n",
+      "  weight_kg           :    806 values →      1 nullified (  0.1%)\n",
+      "Using directly provided parameters\n",
+      "Loading clif_labs.parquet\n",
+      "Data loaded successfully from clif_labs.parquet\n",
+      "lab_order_dttm: null count before conversion= 43419\n",
+      "lab_order_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "lab_order_dttm: null count after conversion= 43419\n",
+      "lab_collect_dttm: null count before conversion= 0\n",
+      "lab_collect_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "lab_collect_dttm: null count after conversion= 0\n",
+      "lab_result_dttm: null count before conversion= 0\n",
+      "lab_result_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "lab_result_dttm: null count after conversion= 0\n",
+      "Using directly provided parameters\n",
+      "Loading clif_patient_assessments.parquet\n",
+      "Data loaded successfully from clif_patient_assessments.parquet\n",
+      "recorded_dttm: null count before conversion= 0\n",
+      "recorded_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "recorded_dttm: null count after conversion= 0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using directly provided parameters\n",
+      "Loading clif_medication_admin_continuous.parquet\n",
+      "Data loaded successfully from clif_medication_admin_continuous.parquet\n",
+      "admin_dttm: null count before conversion= 0\n",
+      "admin_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "admin_dttm: null count after conversion= 0\n",
+      "No weight_kg column found, adding the most recent from vitals\n",
+      "==================================================\n",
+      "=== WIDE DATASET CREATION STARTED ===\n",
+      "==================================================\n",
+      "\n",
+      "Phase 1: Initialization\n",
+      "  1.1: Validating parameters\n",
+      "  1.2: Configuring encounter stitching (enabled)\n",
+      "\n",
+      "Phase 2: Encounter Processing\n",
+      "  2.1: === SPECIAL: ENCOUNTER STITCHING ===\n",
+      "       - No encounter_blocks provided - processing all encounter blocks\n",
+      "\n",
+      "Phase 3: Table Loading\n",
+      "  3.1: Auto-loading base tables\n",
+      "       - Loading patient table...\n",
+      "Using directly provided parameters\n",
+      "Loading clif_patient.parquet\n",
+      "Data loaded successfully from clif_patient.parquet\n",
+      "death_dttm: null count before conversion= 85\n",
+      "death_dttm: Converted from UTC to your timezone (US/Eastern).\n",
+      "death_dttm: null count after conversion= 85\n",
+      "  3.2: Loading optional tables: None\n",
+      "  === SPECIAL: PATIENT ASSESSMENTS PROCESSING ===\n",
+      "       - Merging numerical_value and categorical_value columns\n",
+      "       - Using Polars for performance optimization\n",
+      "       - WARNING: Found 9951 rows with both values!\n",
+      "       -          Numerical values will take precedence\n",
+      "       - Created assessment_value column:\n",
+      "       -   27454 numerical values (takes precedence)\n",
+      "       -   13222 categorical values (used when numerical is null)\n",
+      "       -   Total non-null assessment values: 30725\n",
+      "       -   Stored as string type for processing compatibility\n",
+      "\n",
+      "Phase 4: Calling Wide Dataset Utility\n",
+      "  4.1: Passing to wide_dataset.create_wide_dataset()\n",
+      "       - Tables: None\n",
+      "       - Category filters: ['labs', 'vitals', 'patient_assessments', 'medication_admin_continuous']\n",
+      "       - Batch size: 1000\n",
+      "       - Memory limit: None\n",
+      "       - Show progress: True\n",
+      "\n",
+      "Phase 4: Wide Dataset Processing (utility function)\n",
+      "  4.1: Starting wide dataset creation...\n",
+      "Processing all 275 hospitalizations\n",
+      "\n",
+      "Loading and filtering base tables...\n",
+      "       - Base tables filtered - Hospitalization: 275, Patient: 100, ADT: 1136\n",
+      "\n",
+      "  4.2: Determining processing mode\n",
+      "       - Single mode: Processing all 275 hospitalizations at once\n",
+      "  4.S: === SINGLE PROCESSING MODE ===\n",
+      "    4.S.1: Loading and filtering base tables\n",
+      "           - Base cohort created with 275 records\n",
+      "    4.S.3: Processing tables\n",
+      "           - Processing labs...\n",
+      "Loaded 43419 records from labs\n",
+      "           === PIVOTING LABS ===\n",
+      "           - Categories to pivot: ['creatinine', 'platelet_count', 'po2_arterial', 'bilirubin_total']\n",
+      "Filtering labs categories to: ['creatinine', 'platelet_count', 'po2_arterial', 'bilirubin_total']\n",
+      "Pivoted labs: 5524 combo_ids with 4 category columns\n",
+      "           - Processing vitals...\n",
+      "Loaded 89085 records from vitals\n",
+      "           === PIVOTING VITALS ===\n",
+      "           - Categories to pivot: ['map', 'spo2', 'weight_kg']\n",
+      "Filtering vitals categories to: ['map', 'spo2', 'weight_kg']\n",
+      "Pivoted vitals: 19231 combo_ids with 3 category columns\n",
+      "           - Processing patient_assessments...\n",
+      "Loaded 30803 records from patient_assessments\n",
+      "           === PIVOTING PATIENT_ASSESSMENTS ===\n",
+      "           - Categories to pivot: ['gcs_total']\n",
+      "Filtering patient_assessments categories to: ['gcs_total']\n",
+      "Pivoted patient_assessments: 3279 combo_ids with 1 category columns\n",
+      "           - Processing medication_admin_continuous...\n",
+      "           === SPECIAL: USING CONVERTED MEDICATION DATA ===\n",
+      "           - Including all 6,791 rows: 6,667 successful conversions, 124 (1.8%) fallback to original units\n",
+      "Loaded 6791 records from medication_admin_continuous\n",
+      "           === PIVOTING MEDICATION_ADMIN_CONTINUOUS ===\n",
+      "           - Categories to pivot: ['norepinephrine', 'epinephrine', 'phenylephrine', 'vasopressin', 'dopamine', 'angiotensin', 'dobutamine', 'milrinone']\n",
+      "           - Using converted medication columns: med_dose_converted, med_dose_unit_converted\n",
+      "Filtering medication_admin_continuous categories to: ['norepinephrine', 'epinephrine', 'phenylephrine', 'vasopressin', 'dopamine', 'angiotensin', 'dobutamine', 'milrinone']\n",
+      "           - Creating unit-aware pivot with columns: category_unit format\n",
+      "           - Including both successful conversions and original units for failed conversions\n",
+      "Pivoted medication_admin_continuous: 1924 combo_ids with 7 medication_unit columns\n",
+      "    4.S.4: Creating wide dataset\n",
+      "           - Building event time union from 5 tables\n",
+      "           - Creating combo_id keys\n",
+      "           - Executing main join query\n",
+      "Executing join query...\n",
+      "    === SPECIAL: MISSING COLUMNS ===\n",
+      "           - Found unit-aware columns for norepinephrine: ['norepinephrine_mcg_min']\n",
+      "           - Found unit-aware columns for epinephrine: ['epinephrine_mcg_min']\n",
+      "           - Found unit-aware columns for phenylephrine: ['phenylephrine_mcg_min']\n",
+      "           - Found unit-aware columns for vasopressin: ['vasopressin_u_min']\n",
+      "           - Found unit-aware columns for dopamine: ['dopamine_mcg_min']\n",
+      "           - Added missing column: angiotensin\n",
+      "           - Found unit-aware columns for dobutamine: ['dobutamine_mcg_min']\n",
+      "           - Found unit-aware columns for milrinone: ['milrinone_mcg_min']\n",
+      "\n",
+      "    4.S.6: Final cleanup\n",
+      "           - Removing duplicate columns\n",
+      "           - Dropping temporary columns (combo_id, date)\n",
+      "           - Wide dataset created: 36749 records with 28 columns\n",
+      "\n",
+      "Phase 5: Post-Processing\n",
+      "  5.1: === SPECIAL: ADDING ENCOUNTER BLOCKS ===\n",
+      "       - Encounter_block column already present - 272 unique encounter blocks\n",
+      "  5.2: === SPECIAL: ASSESSMENT TYPE OPTIMIZATION ===\n",
+      "       - Using Polars for performance optimization\n",
+      "       - Analyzing 1 assessment columns\n",
+      "       - Converted to numeric (1 columns):\n",
+      "       -   gcs_total\n",
+      "\n",
+      "Phase 6: Completion\n",
+      "  6.1: Wide dataset stored in self.wide_df\n",
+      "  6.2: Dataset shape: 36749 rows x 28 columns\n",
+      "\n",
+      "==================================================\n",
+      "=== WIDE DATASET CREATION COMPLETED ===\n",
+      "==================================================\n",
+      "\n",
+      "Wide dataset created with shape: (36749, 28)\n",
+      "Columns: ['hospitalization_id', 'patient_id', 'age_at_admission', 'event_time', 'dobutamine_mcg_min', 'dopamine_mcg_min', 'epinephrine_mcg_min', 'milrinone_mcg_min', 'norepinephrine_mcg_min', 'phenylephrine_mcg_min', 'vasopressin_u_min', 'map', 'spo2', 'weight_kg', 'bilirubin_total', 'creatinine', 'platelet_count', 'po2_arterial', 'hospital_id', 'in_dttm', 'out_dttm', 'location_category', 'location_type', 'encounter_block', 'day_number', 'hosp_id_day_key', 'angiotensin', 'gcs_total']\n"
+     ]
+    }
+   ],
    "source": [
     "# # Create the cohort DataFrame\n",
     "# cohort_df = pd.DataFrame({\n",
@@ -289,71 +538,137 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6f683ed0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "clif.load_table('vitals')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5026508b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "apply_outlier_handling(clif.vitals)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e1b3b23a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "clif.vitals.df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "725cafda",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "clif.wide_df.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "29608fb6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['dextrose', 'propofol', 'insulin', 'magnesium', 'heparin',\n",
+       "       'esmolol', 'diltiazem', 'phenylephrine', 'norepinephrine',\n",
+       "       'vasopressin', 'fentanyl', 'amiodarone', 'labetalol',\n",
+       "       'dexmedetomidine', 'sodium bicarbonate', 'pantoprazole', 'tpn',\n",
+       "       'nicardipine', 'dobutamine', 'dopamine', 'midazolam', 'furosemide',\n",
+       "       'morphine', 'octreotide', 'aminocaproic', 'epinephrine',\n",
+       "       'bumetanide', 'milrinone', 'rocuronium', 'hydromorphone'],\n",
+       "      dtype=object)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "clif.medication_admin_continuous.df.med_category.unique()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "3876e0de",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['hospitalization_id',\n",
+       " 'patient_id',\n",
+       " 'age_at_admission',\n",
+       " 'event_time',\n",
+       " 'dobutamine_mcg_min',\n",
+       " 'dopamine_mcg_min',\n",
+       " 'epinephrine_mcg_min',\n",
+       " 'milrinone_mcg_min',\n",
+       " 'norepinephrine_mcg_min',\n",
+       " 'phenylephrine_mcg_min',\n",
+       " 'vasopressin_u_min',\n",
+       " 'map',\n",
+       " 'spo2',\n",
+       " 'weight_kg',\n",
+       " 'bilirubin_total',\n",
+       " 'creatinine',\n",
+       " 'platelet_count',\n",
+       " 'po2_arterial',\n",
+       " 'hospital_id',\n",
+       " 'in_dttm',\n",
+       " 'out_dttm',\n",
+       " 'location_category',\n",
+       " 'location_type',\n",
+       " 'encounter_block',\n",
+       " 'day_number',\n",
+       " 'hosp_id_day_key',\n",
+       " 'angiotensin',\n",
+       " 'gcs_total']"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "clif.wide_df"
+    "clif.wide_df.columns.to_list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3o2t89gdv7s",
+   "metadata": {},
+   "source": [
+    "## Test Hourly Aggregation with Encounter Blocks\n",
+    "\n",
+    "This test demonstrates the new `id_name` parameter in `convert_wide_to_hourly()` which allows aggregating by different ID columns:\n",
+    "- Default: `hospitalization_id` - each hospitalization aggregated separately\n",
+    "- With encounter stitching: `encounter_block` - linked hospitalizations aggregated together"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4a44292",
+   "id": "7gsgdi0y3yk",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": "# Test hourly aggregation with encounter blocks\nimport pandas as pd\n\n# Define aggregation configuration for various column types\naggregation_config = {\n    'mean': ['map', 'spo2', 'weight_kg'],  # Vitals\n    'max': ['creatinine', 'bilirubin_total'],  # Labs - worst values\n    'min': ['platelet_count'],  # Labs - lowest count\n    'first': ['gcs_total'],  # Assessments - first in hour\n    'boolean': ['norepinephrine_mcg_min', 'epinephrine_mcg_min', 'phenylephrine_mcg_min', \n                'vasopressin_u_min', 'dopamine_mcg_min', 'dobutamine_mcg_min', \n                'milrinone_mcg_min']  # Meds - any use in hour\n}\n\n# Make sure we have a wide dataset with encounter_block column\nif 'encounter_block' not in clif.wide_df.columns:\n    print(\"WARNING: encounter_block not in wide_df columns. Ensure encounter stitching was performed.\")\n    print(\"Available columns:\", clif.wide_df.columns.tolist())\nelse:\n    print(f\"Wide dataset ready: {clif.wide_df.shape}\")\n    print(f\"Unique encounter blocks in wide_df: {clif.wide_df['encounter_block'].nunique()}\")\n\n\ntry:\n    hourly_df_enc = clif.convert_wide_to_hourly(\n        aggregation_config=aggregation_config,\n        id_name='encounter_block'\n    )\n    \n    print(f\"✓ Shape: {hourly_df_enc.shape}\")\n    print(f\"✓ Unique encounter_blocks: {hourly_df_enc['encounter_block'].nunique()}\")\n    print(f\"✓ Sample columns: {list(hourly_df_enc.columns)[:10]}...\")\n    print(f\"✓ Hour range: nth_hour {hourly_df_enc['nth_hour'].min()} to {hourly_df_enc['nth_hour'].max()}\")\nexcept Exception as e:\n    print(f\"✗ Error: {e}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "953a7422",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['encounter_block', 'event_time_hour', 'nth_hour', 'hour_bucket',\n",
+       "       'patient_id', 'day_number', 'creatinine_max', 'bilirubin_total_max',\n",
+       "       'platelet_count_min', 'map_mean', 'spo2_mean', 'weight_kg_mean',\n",
+       "       'gcs_total_first', 'hospitalization_id_c', 'age_at_admission_c',\n",
+       "       'dobutamine_mcg_min_c', 'dopamine_mcg_min_c', 'epinephrine_mcg_min_c',\n",
+       "       'milrinone_mcg_min_c', 'norepinephrine_mcg_min_c',\n",
+       "       'phenylephrine_mcg_min_c', 'vasopressin_u_min_c', 'po2_arterial_c',\n",
+       "       'hospital_id_c', 'in_dttm_c', 'out_dttm_c', 'location_category_c',\n",
+       "       'location_type_c', 'hosp_id_day_key_c', 'angiotensin_c'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hourly_df_enc.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5d69397",
+   "metadata": {},
+   "outputs": [],
+   "source": "'mean': ['map', 'spo2', 'weight_kg'],  # Vitals\n'max': ['creatinine', 'bilirubin_total'],  # Labs - worst values\n'min': ['platelet_count'],  # Labs - lowest count\n'first': ['gcs_total'],  # Assessments - first in hour\n'boolean': ['norepinephrine_mcg_min', 'epinephrine_mcg_min', 'phenylephrine_mcg_min', \n            'vasopressin_u_min', 'dopamine_mcg_min', 'dobutamine_mcg_min', \n            'milrinone_mcg_min']  # Meds - any use in hour (unit-aware column names)"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

This PR enhances the hourly aggregation functionality with encounter block support, fixes medication column naming issues in tests, and adds comprehensive documentation for the hourly aggregation feature.

## Key Features Added

### 1. **Encounter Block Aggregation Support** 🏥
- Added `id_name` parameter to `convert_wide_to_hourly()` method
- Enables aggregation by `encounter_block` instead of individual `hospitalization_id`
- Treats linked hospitalizations as continuous stays when encounter stitching is enabled
- Provides flexibility to aggregate by any ID column in the dataset

### 2. **Fixed Unit-Aware Medication Column Handling** 💊
- Corrected test to use proper unit-aware medication column names (e.g., `norepinephrine_mcg_min` instead of `norepinephrine`)
- Ensures boolean aggregation works correctly with converted medication columns
- Added all vasopressors/inotropes to test configuration

### 3. **Comprehensive Documentation Updates** 📚
- Added detailed hourly aggregation documentation in `docs/user-guide/wide-dataset.md`
- Documented all aggregation methods and their corresponding suffixes
- Included examples for both standard and encounter block aggregation
- Added parameter reference table for clarity

## Technical Changes

### Core Library Updates

#### `clifpy/clif_orchestrator.py`
```python
# Added id_name parameter to convert_wide_to_hourly
def convert_wide_to_hourly(
    self,
    aggregation_config: Dict[str, List[str]],
    wide_df: Optional[pd.DataFrame] = None,
    id_name: str = 'hospitalization_id',  # NEW: Support different ID columns
    ...
)
```

#### `clifpy/utils/wide_dataset.py`
- Updated `convert_wide_to_hourly()` to accept and use `id_name` parameter
- Modified `_process_hourly_single_batch()` to group by specified ID column
- Updated `_process_hourly_in_batches()` for flexible ID handling
- Enhanced `_build_aggregation_query_duckdb()` to use dynamic ID column

### Test Updates

#### `tests/test_wide.ipynb`
- Fixed aggregation_config to use unit-aware column names:
  ```python
  'boolean': ['norepinephrine_mcg_min', 'epinephrine_mcg_min', 'phenylephrine_mcg_min',
              'vasopressin_u_min', 'dopamine_mcg_min', 'dobutamine_mcg_min',
              'milrinone_mcg_min']
  ```
- Added comprehensive test for encounter block aggregation
- Demonstrated medication unit conversion workflow with hourly aggregation

### Documentation

#### `docs/user-guide/wide-dataset.md`
- Added "Understanding Hourly Aggregation" section
- Created parameter reference table
- Documented aggregation methods and column suffixes
- Added encounter block aggregation examples
- Included troubleshooting for unit-aware columns

## Use Cases

### 1. Standard Hospitalization Aggregation
```python
hourly_df = co.convert_wide_to_hourly(
    aggregation_config=config,
    id_name='hospitalization_id'  # Default
)
```

### 2. Encounter Block Aggregation
```python
# After encounter stitching
hourly_df = co.convert_wide_to_hourly(
    aggregation_config=config,
    id_name='encounter_block'  # Group linked hospitalizations
)
```

### 3. Unit-Aware Medication Aggregation
```python
config = {
    'boolean': ['norepinephrine_mcg_min', 'epinephrine_mcg_min']  # Correct column names
}
```

## Expected Benefits

1. **Clinical Research**: Enables analysis of patient trajectories across linked encounters
2. **Machine Learning**: Creates consistent hourly features for predictive models
3. **Quality Metrics**: Supports calculation of time-sensitive clinical scores (e.g., SOFA)
4. **Flexibility**: Allows aggregation by different organizational units (hospitalization, encounter, custom)

## Testing

- ✅ Updated test notebook runs successfully with corrected column names
- ✅ Encounter block aggregation produces expected results
- ✅ Unit-aware medication columns aggregate properly with `_boolean` suffix
- ✅ Documentation examples are validated against test cases

## Breaking Changes

None - All changes are backward compatible. The `id_name` parameter defaults to `'hospitalization_id'` maintaining existing behavior.

## Migration Guide

For users with existing code:
1. No changes required - existing code continues to work
2. To use encounter block aggregation, add `id_name='encounter_block'` after enabling encounter stitching
3. For medication columns, ensure using unit-aware names (e.g., `norepinephrine_mcg_min`) after unit conversion

## Related Issues

- Addresses confusion around medication column naming after unit conversion
- Enables encounter-level analysis requested by clinical research teams
- Provides foundation for SOFA score calculation across encounters
